### PR TITLE
尝试修复DeathUI的退出存在bug

### DIFF
--- a/ui/DeathUI.lua
+++ b/ui/DeathUI.lua
@@ -12,6 +12,9 @@ function DeathUI:__init()
 end
 
 function DeathUI:_onUpdate()
+    if ClientState.current ~= ClientState.Gaming then
+        self:closeWindow() -- tried fix stick DeathUI by suddenly close UIWindow
+    end
     if self._cd > 1 then
         self._cd = self._cd - 1
     end


### PR DESCRIPTION
尝试以检测ClientState并瞬间关闭的方式暂时修复DeathUI的退出存在bug
Tried to fix sticking DeathUI by suddenly close UIWindow when not in GamingState